### PR TITLE
Use options object instead of host for versatility

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,14 +3,10 @@
 import jayson from 'jayson/lib/client';
 
 export default {
-  install: function(Vue, url = url, ssl = false) {
-    let client = jayson.http({
-      host: url
-    });
+  install: function(Vue, options = options, ssl = false) {
+    let client = jayson.http(options);
     if (ssl) {
-      client = jayson.https({
-        host: url
-      });
+      client = jayson.https(options);
     }
 
     Object.defineProperty(Vue.prototype, '$JaysonRPC', { value: client });

--- a/index.js
+++ b/index.js
@@ -3,12 +3,8 @@
 import jayson from 'jayson/lib/client';
 
 export default {
-  install: function(Vue, options = options, ssl = false) {
-    let client = jayson.http(options);
-    if (ssl) {
-      client = jayson.https(options);
-    }
-
+  install: function(Vue, options, ssl) {
+    var client = ssl ? jayson.https(options) : jayson.http(options);
     Object.defineProperty(Vue.prototype, '$JaysonRPC', { value: client });
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jayson-rpc-vue",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Jayson rpc client vue integration",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Backwards compatible patch because Jayson will by default treat options as a URL if it's just a string. But if it's an object, then it treats it like an options object for the npm http package. This makes it more versatile when you need fine-grained control.